### PR TITLE
Fix website layout on mobile devices

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -11,10 +11,30 @@ html {
         }
 
         .title-grid {
-            display: grid;
-            grid-template-columns: repeat(2, auto);
+            display: flex;
+            flex-wrap: wrap;
+
+            :first-child {
+                @media (max-width: 991.98px) {
+                    text-align: center;
+                }
+            }
 
             :last-child {
+                @media (max-width: 991.98px) {
+                    text-align: center;
+                }
+                @media (min-width: 992px) {
+                    text-align: right;
+                }
+            }
+        }
+
+        .settings-title {
+            @media (max-width: 767.98px) {
+                margin-top: 1rem;
+            }
+            @media (min-width: 768px) {
                 text-align: right;
             }
         }

--- a/src/views/pages/home.hbs
+++ b/src/views/pages/home.hbs
@@ -27,15 +27,15 @@
 <div class="jumbotron">
     <div class="container">
         <div class="title-grid">
-            <h1 class="display-4">Easy MarkDown Editor</h1>
-            <h1 class="display-4">v{{version}}</h1>
+            <h1 class="display-4 flex-grow-1">Easy MarkDown Editor</h1>
+            <h1 class="display-4 flex-grow-1">v{{version}}</h1>
         </div>
 
         <p class="lead">A simple, beautiful, and embeddable JavaScript Markdown editor. Delightful editing for beginners and experts alike.
             Features built-in autosaving and spell checking.</p>
         <p>A fork of <a href="https://github.com/sparksuite/simplemde-markdown-editor" target="_blank">SimpleMDE</a></p>
         <hr class="my-4">
-        <div class="lead d-flex justify-content-between">
+        <div class="lead d-flex flex-wrap justify-content-between">
             <div>
                 <p>Links</p>
                 <a class="btn btn-lg btn-dark button-github" href="https://github.com/Ionaru/easy-markdown-editor" target="_blank">
@@ -46,7 +46,7 @@
                 </a>
             </div>
             <div>
-                <p class="text-right">Settings</p>
+                <p class="settings-title">Settings</p>
                 <button class="btn btn-lg" onclick="toggleFontAwesomeParameter()">
                     <i class="{{#if useFA4}}fa{{else}}fab{{/if}} fa-font-awesome"></i> FontAwesome {{#if useFA4}}4{{else}}5{{/if}}
                 </button>


### PR DESCRIPTION
Here is how the website looks on an iPhone 5/SE sized device (zoomed out). This PR fixes layout styling on mobile devices and tablets.

<img width="331" alt="Issue on iPhone 5/SE" src="https://user-images.githubusercontent.com/40002855/78538815-70dc8c80-77a6-11ea-9b62-8819b6e16181.png">

| Before | After |
| --- | --- |
| <img width="331" alt="Before Pic 1" src="https://user-images.githubusercontent.com/40002855/78538819-72a65000-77a6-11ea-9120-546a3eb9751c.png"> | <img width="331" alt="After Pic 1" src="https://user-images.githubusercontent.com/40002855/78538822-733ee680-77a6-11ea-9ff9-5d1919c03f14.png"> |
| <img width="331" alt="Before Pic 2" src="https://user-images.githubusercontent.com/40002855/78538825-73d77d00-77a6-11ea-9f03-d424a0447609.png"> | <img width="331" alt="After Pic 2" src="https://user-images.githubusercontent.com/40002855/78538824-73d77d00-77a6-11ea-93a6-8c7d4e0c9fb6.png"> |
